### PR TITLE
chore: use null instead of undefined for api semantics

### DIFF
--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -104,9 +104,9 @@ export class Ipv4Addr implements IpAddrValue {
 	 * of an unsigned 8-bit integer, 0 to 255), each separated by a dot.
 	 *
 	 * If the string does not conform to the format, it will
-	 * return `undefined`.
+	 * return `null`.
 	 */
-	public static parse(s: string): Ipv4Addr | undefined {
+	public static parse(s: string): Ipv4Addr | null {
 		const [result, _] = parseIpv4Addr(s)
 		return result
 	}
@@ -114,12 +114,12 @@ export class Ipv4Addr implements IpAddrValue {
 	/**
 	 * Attempts to create an `Ipv4Addr` from an array of numbers.
 	 *
-	 * This returns `undefined` if the array length is not equal to 4,
+	 * This returns `null` if the array length is not equal to 4,
 	 * otherwise returns an `Ipv4Addr`.
 	 */
-	public static tryFromArray(array: number[]): Ipv4Addr | undefined {
+	public static tryFromArray(array: number[]): Ipv4Addr | null {
 		if (array.length !== 4) {
-			return undefined
+			return null
 		}
 
 		return Ipv4Addr.newAddr(
@@ -133,24 +133,24 @@ export class Ipv4Addr implements IpAddrValue {
 	/**
 	 * Attempts to create an `Ipv4Addr` from a `Uint8Array`.
 	 *
-	 * This returns `undefined` if the array length is not equal to 4,
+	 * This returns `null` if the array length is not equal to 4,
 	 * otherwise returns an `Ipv4Addr`.
 	 */
 	public static tryFromUint8Array(
 		array: Uint8Array,
-	): Ipv4Addr | undefined {
-		return (array.length === 4) ? new Ipv4Addr(array) : undefined
+	): Ipv4Addr | null {
+		return (array.length === 4) ? new Ipv4Addr(array) : null
 	}
 
 	/**
 	 * Attempts to create an `Ipv4Addr` from a `DataView`.
 	 *
-	 * This returns `undefined` if the view is not 4 bytes long,
+	 * This returns `null` if the view is not 4 bytes long,
 	 * otherwise returns an `Ipv4Addr`.
 	 */
-	public static tryFromDataView(view: DataView): Ipv4Addr | undefined {
+	public static tryFromDataView(view: DataView): Ipv4Addr | null {
 		if (view.byteLength !== 4) {
-			return undefined
+			return null
 		}
 
 		return new Ipv4Addr(
@@ -173,12 +173,12 @@ export class Ipv4Addr implements IpAddrValue {
 	/**
 	 * Returns the address that occurs before this address.
 	 *
-	 * If the current address is `0.0.0.0`, this returns undefined.
+	 * If the current address is `0.0.0.0`, this returns null.
 	 */
-	public previous(): Ipv4Addr | undefined {
+	public previous(): Ipv4Addr | null {
 		const n = uint8ArrayToUint32(this.octets) - 1
 		if (n < 0) {
-			return undefined
+			return null
 		}
 
 		return Ipv4Addr.fromUint32(n)
@@ -187,12 +187,12 @@ export class Ipv4Addr implements IpAddrValue {
 	/**
 	 * Returns the address that occurs after this address.
 	 *
-	 * If the current address is `255.255.255.255`, this returns undefined.
+	 * If the current address is `255.255.255.255`, this returns null.
 	 */
-	public next(): Ipv4Addr | undefined {
+	public next(): Ipv4Addr | null {
 		const n = uint8ArrayToUint32(this.octets) + 1
 		if (n > 65535) {
-			return undefined
+			return null
 		}
 
 		return Ipv4Addr.fromUint32(n)

--- a/src/ipv4_test.ts
+++ b/src/ipv4_test.ts
@@ -54,7 +54,7 @@ Deno.test('try from array is ok', () => {
 
 Deno.test('try from array is error', () => {
 	const addr = Ipv4Addr.tryFromArray([1, 2, 3, 4, 5])
-	assertEquals(addr, undefined)
+	assertEquals(addr, null)
 })
 
 Deno.test('try from uint8array is ok', () => {
@@ -75,7 +75,7 @@ Deno.test('try from uint8array is error', () => {
 			new ArrayBuffer(5),
 		),
 	)
-	assertEquals(addr, undefined)
+	assertEquals(addr, null)
 })
 
 Deno.test('try from dataview is ok', () => {
@@ -91,7 +91,7 @@ Deno.test('try from dataview is ok', () => {
 
 Deno.test('try from dataview is error', () => {
 	const view = new DataView(new ArrayBuffer(5))
-	assertEquals(Ipv4Addr.tryFromDataView(view), undefined)
+	assertEquals(Ipv4Addr.tryFromDataView(view), null)
 })
 
 Deno.test('to string', () => {
@@ -99,9 +99,9 @@ Deno.test('to string', () => {
 	assertEquals(localhost.toString(), '127.0.0.1')
 })
 
-Deno.test('previous: 0.0.0.0 -> undefined', () => {
+Deno.test('previous: 0.0.0.0 -> null', () => {
 	const addr = Ipv4Addr.UNSPECIFIED
-	assertEquals(addr.previous(), undefined)
+	assertEquals(addr.previous(), null)
 })
 
 Deno.test('previous: 255.255.255.255 -> 255.255.255.254', () => {
@@ -114,9 +114,9 @@ Deno.test('previous: 0.0.1.0 -> 0.0.0.255', () => {
 	assert(addr.previous()?.equals(Ipv4Addr.newAddr(0, 0, 0, 255)))
 })
 
-Deno.test('next: 255.255.255.255 -> undefined', () => {
+Deno.test('next: 255.255.255.255 -> null', () => {
 	const addr = Ipv4Addr.BROADCAST
-	assertEquals(addr.next(), undefined)
+	assertEquals(addr.next(), null)
 })
 
 Deno.test('next: 0.0.0.0 -> 0.0.0.1', () => {
@@ -256,10 +256,10 @@ Deno.test('parse 255.255.255.255 is ok', () => {
 
 Deno.test('parse errors because number is too big', () => {
 	const maybeIp = Ipv4Addr.parse('256.255.255.255')
-	assertEquals(maybeIp, undefined)
+	assertEquals(maybeIp, null)
 })
 
 Deno.test('parse errors because of no dot', () => {
 	const maybeIp = Ipv4Addr.parse('127!0.0.1')
-	assertEquals(maybeIp, undefined)
+	assertEquals(maybeIp, null)
 })

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -124,12 +124,12 @@ export class Ipv6Addr implements IpAddrValue {
 	/**
 	 * Attempts to create an `Ipv6Addr` from an array of numbers.
 	 *
-	 * This returns `undefined` if the array length is not equal to 8,
+	 * This returns `null` if the array length is not equal to 8,
 	 * otherwise returns an `Ipv6Addr`.
 	 */
-	public static tryFromArray(array: number[]): Ipv6Addr | undefined {
+	public static tryFromArray(array: number[]): Ipv6Addr | null {
 		if (array.length !== 8) {
-			return undefined
+			return null
 		}
 
 		return Ipv6Addr.newAddr(
@@ -147,22 +147,22 @@ export class Ipv6Addr implements IpAddrValue {
 	/**
 	 * Attempts to create an `Ipv6Addr` from a `Uint16Array`.
 	 *
-	 * This returns `undefined` if the array length is not equal to 8,
+	 * This returns `null` if the array length is not equal to 8,
 	 * otherwise returns an `Ipv6Addr`.
 	 */
-	public static tryFromUint16Array(array: Uint16Array): Ipv6Addr | undefined {
-		return (array.length === 8) ? new Ipv6Addr(array) : undefined
+	public static tryFromUint16Array(array: Uint16Array): Ipv6Addr | null {
+		return (array.length === 8) ? new Ipv6Addr(array) : null
 	}
 
 	/**
 	 * Attempts to create an `Ipv6Addr` from a `DataView`.
 	 *
-	 * This returns `undefined` if the view is not 16 bytes long,
+	 * This returns `null` if the view is not 16 bytes long,
 	 * otherwise returns an `Ipv6Addr`.
 	 */
-	public static tryFromDataView(view: DataView): Ipv6Addr | undefined {
+	public static tryFromDataView(view: DataView): Ipv6Addr | null {
 		if (view.byteLength !== 16) {
-			return undefined
+			return null
 		}
 
 		return new Ipv6Addr(
@@ -370,9 +370,9 @@ export class Ipv6Addr implements IpAddrValue {
 	 *
 	 * [rfc7346]: https://datatracker.ietf.org/doc/html/rfc7346#section-2
 	 */
-	public multicastScope(): MulticastScope | undefined {
+	public multicastScope(): MulticastScope | null {
 		if (!this.isMulticast()) {
-			return undefined
+			return null
 		}
 
 		switch (this.a & 0x000f) {
@@ -391,7 +391,7 @@ export class Ipv6Addr implements IpAddrValue {
 			case 14:
 				return 'Global'
 			default:
-				return undefined
+				return null
 		}
 	}
 }

--- a/src/ipv6_test.ts
+++ b/src/ipv6_test.ts
@@ -52,7 +52,7 @@ Deno.test('try from array is ok', () => {
 
 Deno.test('try from array is error', () => {
 	const addr = Ipv6Addr.tryFromArray([1, 2, 3, 4, 5, 6, 7, 8, 9])
-	assertEquals(addr, undefined)
+	assertEquals(addr, null)
 })
 
 Deno.test('try from uint16array is ok', () => {
@@ -74,7 +74,7 @@ Deno.test('try from uint16array is error', () => {
 	const addr = Ipv6Addr.tryFromUint16Array(
 		new Uint16Array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
 	)
-	assertEquals(addr, undefined)
+	assertEquals(addr, null)
 })
 
 Deno.test('try from dataview is ok', () => {
@@ -84,7 +84,7 @@ Deno.test('try from dataview is ok', () => {
 
 Deno.test('try from dataview is error', () => {
 	const addr = Ipv6Addr.tryFromDataView(new DataView(new ArrayBuffer(17)))
-	assertEquals(addr, undefined)
+	assertEquals(addr, null)
 })
 
 Deno.test('localhost to full string', () => {
@@ -351,10 +351,10 @@ Deno.test('multicast scope: global', () => {
 Deno.test('multicast scope: unknown', () => {
 	assertEquals(
 		Ipv6Addr.LOCALHOST.multicastScope(),
-		undefined,
+		null,
 	)
 	assertEquals(
 		Ipv6Addr.newAddr(0xffff, 0, 0, 0, 0, 0, 0, 0).multicastScope(),
-		undefined,
+		null,
 	)
 })

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,10 +3,10 @@ import { takeAsciiDigits } from './utils.ts'
 
 /**
  * - A tuple where:
- * - the first member is either the resulting type, or undefined
+ * - the first member is either the resulting type, or null
  * - the second member is the index where the parser finally left off at
  */
-type ParseResult<T> = [T | undefined, number]
+type ParseResult<T> = [T | null, number]
 
 export function parseIpv4Addr(s: string): ParseResult<Ipv4Addr> {
 	const array = new Uint8Array(4)
@@ -19,7 +19,7 @@ export function parseIpv4Addr(s: string): ParseResult<Ipv4Addr> {
 		// parse octet
 		const octetNumber: number = Number.parseInt(octetString, 10)
 		if (octetNumber < 0 || octetNumber > 255) {
-			return [undefined, idx]
+			return [null, idx]
 		}
 		array[seenDots] = octetNumber
 		idx = newIdx
@@ -27,7 +27,7 @@ export function parseIpv4Addr(s: string): ParseResult<Ipv4Addr> {
 		// check for next dot
 		if (seenDots < 3) {
 			if (s[newIdx] !== '.') {
-				return [undefined, idx]
+				return [null, idx]
 			}
 			idx++
 		}

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -26,27 +26,27 @@ export class SocketAddrV4 {
 	 * Parses a string in the format of `"ipv4:port"`,
 	 * where the port is an unsigned 16-bit integer.
 	 *
-	 * This will return undefined if:
+	 * This will return null if:
 	 * - The IPv4 address cannot be parsed.
 	 * - The IPV4 address can be parsed, but there's no `:` delimiter.
 	 * - The port number can't be parsed, or is out of bounds of an unsigned
 	 *   16-bit integer (0 to 65,535).
 	 */
-	public static parse(s: string): SocketAddrV4 | undefined {
+	public static parse(s: string): SocketAddrV4 | null {
 		const [addr, idx] = parseIpv4Addr(s)
-		if (addr === undefined) {
-			return undefined
+		if (addr === null) {
+			return null
 		}
 
 		const afterAddr = idx
 		if (s[afterAddr] !== ':') {
-			return undefined
+			return null
 		}
 
 		const [portStr, _] = takeAsciiDigits(s, afterAddr + 1)
 		const portNum = Number.parseInt(portStr, 10)
 		if (Number.isNaN(portNum) || portNum > 65535) {
-			return undefined
+			return null
 		}
 
 		return new SocketAddrV4(addr, portNum)
@@ -86,11 +86,11 @@ export class SocketAddrV6 {
 	 *
 	 * TODO: Finish this implementation
 	 */
-	public static fromString(s: string): SocketAddrV6 | undefined {
+	public static fromString(s: string): SocketAddrV6 | null {
 		if (s[0] !== '[') {
-			return undefined
+			return null
 		}
 
-		return undefined
+		return null
 	}
 }

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -11,30 +11,30 @@ Deno.test('socket addresss v4: parse is ok', () => {
 
 Deno.test('socket address v4: parse is error, empty string', () => {
 	const socket = SocketAddrV4.parse('')
-	assertEquals(socket, undefined)
+	assertEquals(socket, null)
 })
 
 Deno.test('socket address v4: parse is error, no ipv4 address', () => {
 	const socket = SocketAddrV4.parse(':8080')
-	assertEquals(socket, undefined)
+	assertEquals(socket, null)
 })
 
 Deno.test('socket address v4: parse is error, invalid ipv4 address', () => {
 	const socket = SocketAddrV4.parse('256.0.0.1:8080')
-	assertEquals(socket, undefined)
+	assertEquals(socket, null)
 })
 
 Deno.test('socket address v4: parse is error, no colon delimiter', () => {
 	const socket = SocketAddrV4.parse('127.0.0.1!8080')
-	assertEquals(socket, undefined)
+	assertEquals(socket, null)
 })
 
 Deno.test('socket address v4: parse is error, no port', () => {
 	const socket = SocketAddrV4.parse('127.0.0.1:')
-	assertEquals(socket, undefined)
+	assertEquals(socket, null)
 })
 
 Deno.test('socket address v4: parse is error, port is out of bounds', () => {
 	const socket = SocketAddrV4.parse('127.0.0.1:65536')
-	assertEquals(socket, undefined)
+	assertEquals(socket, null)
 })


### PR DESCRIPTION
see ecma 262:
- https://262.ecma-international.org/15.0/index.html#sec-undefined-value
- https://262.ecma-international.org/15.0/index.html#sec-null-value

```
4.4.13 undefined value
primitive value used when a variable has not been assigned a value

4.4.15 null value
primitive value that represents the intentional absence of any object value
```