### PR TITLE
parse: don't infinitely allocate + take ASCII digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.1 (2024-11-18)
+
+- The parser for IPv4 addresses and socket addresses no longer takes as many ASCII digits as possible.
+  - IPv4Addr: the parser will now only take 1 to 3 digits for each octet
+  - SocketAddrV4: the parser will now only take 1 to 5 digits for the port number
+
+## 0.1.0 (2024-11-17)
+
+- Initial unstable release of library

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nc/net-addr",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"license": "MIT",
 	"tasks": {
 		"dev": "deno test --watch src/mod.ts"

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,7 +1,7 @@
 import type { Ipv4Addr } from './ipv4.ts'
 import type { Ipv6Addr } from './ipv6.ts'
-import { parseIpv4Addr } from './parser.ts'
-import { clampUint16, takeAsciiDigits } from './utils.ts'
+import { parseSocketAddrV4 } from './parser.ts'
+import { clampUint16 } from './utils.ts'
 
 /**
  * A socket address, containing an IPv4 address and a port number.
@@ -19,7 +19,7 @@ export class SocketAddrV4 {
 	 */
 	public constructor(addr: Ipv4Addr, port: number) {
 		this.addr = addr
-		this.port = clampUint16(port)
+		this.port = port
 	}
 
 	/**
@@ -33,23 +33,8 @@ export class SocketAddrV4 {
 	 *   16-bit integer (0 to 65,535).
 	 */
 	public static parse(s: string): SocketAddrV4 | null {
-		const [addr, idx] = parseIpv4Addr(s)
-		if (addr === null) {
-			return null
-		}
-
-		const afterAddr = idx
-		if (s[afterAddr] !== ':') {
-			return null
-		}
-
-		const [portStr, _] = takeAsciiDigits(s, afterAddr + 1)
-		const portNum = Number.parseInt(portStr, 10)
-		if (Number.isNaN(portNum) || portNum > 65535) {
-			return null
-		}
-
-		return new SocketAddrV4(addr, portNum)
+		const [socket, _] = parseSocketAddrV4(s)
+		return socket
 	}
 
 	/**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,12 +37,20 @@ export function isAsciiDigit(v: string): boolean {
 export function takeAsciiDigits(
 	s: string,
 	at: number,
+	atLeast: number,
+	atMost: number,
 ): [string, number] {
 	let taken = ''
 	let idx = at
-	while (idx < s.length && isAsciiDigit(s[idx])) {
+
+	while (idx < s.length && taken.length < atMost && isAsciiDigit(s[idx])) {
 		taken += s[idx]
 		idx++
 	}
+
+	if (taken.length < atLeast) {
+		return ['', idx]
+	}
+
 	return [taken, idx]
 }


### PR DESCRIPTION
The parser for IPv4 addresses and socket addresses no longer takes as many ASCII digits as possible.
- IPv4Addr: the parser will now only take 1 to 3 digits for each octet
- SocketAddrV4: the parser will now only take 1 to 5 digits for the port number