### PR TITLE
release: v0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## 0.2.0 (2024-11-18)
 
+### Breaking changes
+- The properties of `Ipv4Addr` and `Ipv6Addr` are now readonly.
+- The properties of `SocketAddrV4` and `SocketAddrV6` are now readonly.
+- `SocketAddrV6.fromString()` is renamed to `SocketAddrV6.parse()` to be consistent with `SocketAddrV4.parse()`. (**Note**: This method is not currently implemented yet, and will throw an error when called)
+
+### Features
 - The interface `IpAddrValue` now exposes an `octets()` method that returns a `Uint8Array`.
-- To prevent internal mutability of `IPv4Addr` and `IPv6Addr`, `IPv4Addr.octets` and `IPv6Addr.segments` are now readonly.
+- `SocketAddrV4` and `SocketAddrV6` now exposes a static `tryNew()` method. This method will check if the port number is a valid, unsigned 16-bit integer.
+- `SocketAddrV4` and `SocketAddrV6` now have a note on their constructors which states that the caller is responsible for checking that the port is a valid, unsigned 16-bit integer.
+
 
 ## 0.1.1 (2024-11-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0 (2024-11-18)
+
+- The interface `IpAddrValue` now exposes an `octets()` method that returns a `Uint8Array`.
+- To prevent internal mutability of `IPv4Addr` and `IPv6Addr`, `IPv4Addr.octets` and `IPv6Addr.segments` are now readonly.
+
 ## 0.1.1 (2024-11-18)
 
 - The parser for IPv4 addresses and socket addresses no longer takes as many ASCII digits as possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,16 @@
 ## 0.2.0 (2024-11-18)
 
 ### Breaking changes
+
+- The interface `IpAddrValue` now exposes an `octets()` method that returns a `Uint8Array`.
 - The properties of `Ipv4Addr` and `Ipv6Addr` are now readonly.
 - The properties of `SocketAddrV4` and `SocketAddrV6` are now readonly.
 - `SocketAddrV6.fromString()` is renamed to `SocketAddrV6.parse()` to be consistent with `SocketAddrV4.parse()`. (**Note**: This method is not currently implemented yet, and will throw an error when called)
 
 ### Features
-- The interface `IpAddrValue` now exposes an `octets()` method that returns a `Uint8Array`.
+
 - `SocketAddrV4` and `SocketAddrV6` now exposes a static `tryNew()` method. This method will check if the port number is a valid, unsigned 16-bit integer.
 - `SocketAddrV4` and `SocketAddrV6` now have a note on their constructors which states that the caller is responsible for checking that the port is a valid, unsigned 16-bit integer.
-
 
 ## 0.1.1 (2024-11-18)
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nc/net-addr",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"license": "MIT",
 	"tasks": {
 		"dev": "deno test --watch src/mod.ts"

--- a/src/ip.ts
+++ b/src/ip.ts
@@ -5,7 +5,13 @@ import { Ipv6Addr } from './mod.ts'
  * A representation of an IP address
  */
 export interface IpAddrValue {
-	/** Checks if this address equals another IP address */
+	/**
+	 * The array of unsigned 8-bit integers that make up this address.
+	 */
+	octets(): Uint8Array
+	/**
+	 * Checks if this address equals another IP address.
+	 */
 	equals(other: this): boolean
 	/**
 	 * Checks if this address is a benchmarking address.
@@ -59,7 +65,14 @@ export class IpAddr implements IpAddrValue {
 	}
 
 	/**
-	 * Checks if this address equals another IP address
+	 * The array of unsigned 8-bit integers that make up this address.
+	 */
+	octets(): Uint8Array {
+		return this.addr.octets()
+	}
+
+	/**
+	 * Checks if this address equals another IP address.
 	 */
 	equals(other: IpAddr): boolean {
 		return this.addr.equals(other)

--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -21,10 +21,11 @@ export class Ipv4Addr implements IpAddrValue {
 		new Uint8Array([0, 0, 0, 0]),
 	)
 
-	/** A fixed-size array of 4 octets */
-	public octets: Uint8Array
+	/** A fixed-size array of 4 unsigned 8-bit integers */
+	private _octets: Uint8Array
+
 	private constructor(octets: Uint8Array) {
-		this.octets = octets
+		this._octets = octets
 	}
 
 	/**
@@ -32,7 +33,7 @@ export class Ipv4Addr implements IpAddrValue {
 	 * from bits 0-7.
 	 */
 	public get a(): number {
-		return this.octets[0]
+		return this._octets[0]
 	}
 
 	/**
@@ -40,7 +41,7 @@ export class Ipv4Addr implements IpAddrValue {
 	 * from bits 8-15.
 	 */
 	public get b(): number {
-		return this.octets[1]
+		return this._octets[1]
 	}
 
 	/**
@@ -48,7 +49,7 @@ export class Ipv4Addr implements IpAddrValue {
 	 * from bits 16-23.
 	 */
 	public get c(): number {
-		return this.octets[2]
+		return this._octets[2]
 	}
 
 	/**
@@ -56,7 +57,7 @@ export class Ipv4Addr implements IpAddrValue {
 	 * from bits 24-31.
 	 */
 	public get d(): number {
-		return this.octets[3]
+		return this._octets[3]
 	}
 
 	/**
@@ -176,7 +177,7 @@ export class Ipv4Addr implements IpAddrValue {
 	 * If the current address is `0.0.0.0`, this returns null.
 	 */
 	public previous(): Ipv4Addr | null {
-		const n = uint8ArrayToUint32(this.octets) - 1
+		const n = uint8ArrayToUint32(this._octets) - 1
 		if (n < 0) {
 			return null
 		}
@@ -190,12 +191,19 @@ export class Ipv4Addr implements IpAddrValue {
 	 * If the current address is `255.255.255.255`, this returns null.
 	 */
 	public next(): Ipv4Addr | null {
-		const n = uint8ArrayToUint32(this.octets) + 1
+		const n = uint8ArrayToUint32(this._octets) + 1
 		if (n > 65535) {
 			return null
 		}
 
 		return Ipv4Addr.fromUint32(n)
+	}
+
+	/**
+	 * A fixed-size array of 4 unsigned 8-bit integers.
+	 */
+	public octets(): Uint8Array {
+		return this._octets
 	}
 
 	/**
@@ -242,9 +250,9 @@ export class Ipv4Addr implements IpAddrValue {
 	 * [rfc5737]: https://datatracker.ietf.org/doc/html/rfc5737
 	 */
 	public isDocumentation(): boolean {
-		return arrayStartsWith(this.octets, new Uint8Array([192, 0, 2])) ||
-			arrayStartsWith(this.octets, new Uint8Array([198, 51, 100])) ||
-			arrayStartsWith(this.octets, new Uint8Array([203, 0, 113]))
+		return arrayStartsWith(this._octets, new Uint8Array([192, 0, 2])) ||
+			arrayStartsWith(this._octets, new Uint8Array([198, 51, 100])) ||
+			arrayStartsWith(this._octets, new Uint8Array([203, 0, 113]))
 	}
 
 	/**
@@ -278,7 +286,7 @@ export class Ipv4Addr implements IpAddrValue {
 	 * [rfc3927]: https://datatracker.ietf.org/doc/html/rfc3927
 	 */
 	public isLinkLocal(): boolean {
-		return arrayStartsWith(this.octets, new Uint8Array([169, 254]))
+		return arrayStartsWith(this._octets, new Uint8Array([169, 254]))
 	}
 
 	/**

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -21,67 +21,88 @@ export class Ipv6Addr implements IpAddrValue {
 		new Uint16Array([0, 0, 0, 0, 0, 0, 0, 0])
 	)
 
-	/** A fixed-size array of 8 unsigned 16-bit segments */
-	public segments: Uint16Array
+	/** A fixed-size array of 8 unsigned 16-bit integers */
+	private readonly _segments: Uint16Array
 
 	private constructor(segments: Uint16Array) {
-		this.segments = segments
+		this._segments = segments
+	}
+
+	/**
+	 * A fixed-size array of 16 unsigned 8-bit integers
+	 */
+	public octets(): Uint8Array {
+		const uint8Array = new Uint8Array(16)
+		for (let i = 0; i < 8; i++) {
+			const idx = i * 2
+			const hextet = this._segments[i]
+			uint8Array[idx] = hextet & 0xff // Lower 8 bits
+			uint8Array[idx + 1] = (hextet >> 8) & 0xff // Upper 8 bits
+		}
+		return uint8Array
+	}
+
+	/**
+	 * A fixed-size array of 8 unsigned 16-bit integers.
+	 */
+	public segments(): Uint16Array {
+		return this._segments
 	}
 
 	/**
 	 * The first segment of the IPv6 address in network byte order,
 	 * from bits 0-15.
 	 */
-	get a(): number {
-		return this.segments[0]
+	public get a(): number {
+		return this._segments[0]
 	}
 
 	/**
 	 * The second segment of the IPv6 address in network byte order,
 	 * from bits 16-31.
 	 */
-	get b(): number {
-		return this.segments[1]
+	public get b(): number {
+		return this._segments[1]
 	}
 
 	/**
 	 * The third segment of the IPv6 address in network byte order,
 	 * from bits 32-47.
 	 */
-	get c(): number {
-		return this.segments[2]
+	public get c(): number {
+		return this._segments[2]
 	}
 
 	/**
 	 * The fourth segment of the IPv6 address in network byte order,
 	 * from bits 48-63.
 	 */
-	get d(): number {
-		return this.segments[3]
+	public get d(): number {
+		return this._segments[3]
 	}
 
 	/**
 	 * The fifth segment of the IPv6 address in network byte order,
 	 * from bits 64-79.
 	 */
-	get e(): number {
-		return this.segments[4]
+	public get e(): number {
+		return this._segments[4]
 	}
 
 	/**
 	 * The sixth segment of the IPv6 address in network byte order,
 	 * from bits 80-95.
 	 */
-	get f(): number {
-		return this.segments[5]
+	public get f(): number {
+		return this._segments[5]
 	}
 
 	/**
 	 * The seventh segment of the IPv6 address in network byte order,
 	 * from bits 96-111.
 	 */
-	get g(): number {
-		return this.segments[6]
+	public get g(): number {
+		return this._segments[6]
 	}
 
 	/**
@@ -89,7 +110,7 @@ export class Ipv6Addr implements IpAddrValue {
 	 * from bits 112-127.
 	 */
 	get h(): number {
-		return this.segments[7]
+		return this._segments[7]
 	}
 
 	/**
@@ -185,7 +206,7 @@ export class Ipv6Addr implements IpAddrValue {
 	 */
 	public toString(): string {
 		const hextets = []
-		for (const segment of this.segments) {
+		for (const segment of this._segments) {
 			hextets.push(segment.toString(16).padStart(4, '0'))
 		}
 		return hextets.join(':')
@@ -243,15 +264,15 @@ export class Ipv6Addr implements IpAddrValue {
 
 		return !(this.isUnspecified()
 			|| this.isLoopback()
-			|| arrayStartsWith(this.segments, ipv4Mapped)
-			|| arrayStartsWith(this.segments, ipv4Translated)
-			|| arrayStartsWith(this.segments, discardOnly)
+			|| arrayStartsWith(this._segments, ipv4Mapped)
+			|| arrayStartsWith(this._segments, ipv4Translated)
+			|| arrayStartsWith(this._segments, discardOnly)
 			|| (
 				(this.a === 0x2001 && this.b < 0x200) && !(
-					uint128FromHextets(this.segments) === BigInt("0x20010001000000000000000000000001")
-					|| uint128FromHextets(this.segments) === BigInt("0x20010001000000000000000000000002")
-					|| arrayStartsWith(this.segments, new Uint16Array([0x2001, 0x3]))
-					|| arrayStartsWith(this.segments, new Uint16Array([0x2001, 4, 0x112]))
+					uint128FromArray(this._segments) === BigInt("0x20010001000000000000000000000001")
+					|| uint128FromArray(this._segments) === BigInt("0x20010001000000000000000000000002")
+					|| arrayStartsWith(this._segments, new Uint16Array([0x2001, 0x3]))
+					|| arrayStartsWith(this._segments, new Uint16Array([0x2001, 4, 0x112]))
 					|| (this.a === 0x2001 && (this.b >= 0x10 && this.b <= 0x3f))
 				)
 			)
@@ -267,7 +288,7 @@ export class Ipv6Addr implements IpAddrValue {
 	 */
 	public isIpv4Mapped(): boolean {
 		return arrayStartsWith(
-			this.segments,
+			this._segments,
 			new Uint16Array([0, 0, 0, 0, 0, 0xffff]),
 		)
 	}
@@ -412,7 +433,7 @@ export type MulticastScope =
 	| 'OrganizationLocal'
 	| 'Global'
 
-function uint128FromHextets(array: Uint16Array): bigint {
+function uint128FromArray(array: Uint16Array): bigint {
 	let result = BigInt(0)
 	for (let i = 0; i < array.length; i++) {
 		result = (result << BigInt(16)) | BigInt(array[i])

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -29,20 +29,6 @@ export class Ipv6Addr implements IpAddrValue {
 	}
 
 	/**
-	 * A fixed-size array of 16 unsigned 8-bit integers
-	 */
-	public octets(): Uint8Array {
-		const uint8Array = new Uint8Array(16)
-		for (let i = 0; i < 8; i++) {
-			const idx = i * 2
-			const hextet = this._segments[i]
-			uint8Array[idx] = hextet & 0xff // Lower 8 bits
-			uint8Array[idx + 1] = (hextet >> 8) & 0xff // Upper 8 bits
-		}
-		return uint8Array
-	}
-
-	/**
 	 * A fixed-size array of 8 unsigned 16-bit integers.
 	 */
 	public segments(): Uint16Array {
@@ -210,6 +196,20 @@ export class Ipv6Addr implements IpAddrValue {
 			hextets.push(segment.toString(16).padStart(4, '0'))
 		}
 		return hextets.join(':')
+	}
+
+	/**
+	 * A fixed-size array of 16 unsigned 8-bit integers
+	 */
+	public octets(): Uint8Array {
+		const uint8Array = new Uint8Array(16)
+		for (let i = 0; i < 8; i++) {
+			const idx = i * 2
+			const hextet = this._segments[i]
+			uint8Array[idx] = hextet & 0xff // Lower 8 bits
+			uint8Array[idx + 1] = (hextet >> 8) & 0xff // Upper 8 bits
+		}
+		return uint8Array
 	}
 
 	/**

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -206,8 +206,8 @@ export class Ipv6Addr implements IpAddrValue {
 		for (let i = 0; i < 8; i++) {
 			const idx = i * 2
 			const hextet = this._segments[i]
-			uint8Array[idx] = hextet & 0xff // Lower 8 bits
-			uint8Array[idx + 1] = (hextet >> 8) & 0xff // Upper 8 bits
+			uint8Array[idx] = (hextet >> 8) & 0xff // Upper 8 bits
+			uint8Array[idx + 1] = hextet & 0xff // Lower 8 bits
 		}
 		return uint8Array
 	}

--- a/src/ipv6_test.ts
+++ b/src/ipv6_test.ts
@@ -109,6 +109,14 @@ Deno.test('address with hex characters to full string', () => {
 	assertEquals(addr.toString(), '1234:5678:9abc:def0:1234:5678:9abc:def0')
 })
 
+Deno.test('octets', () => {
+	const addr = Ipv6Addr.newAddr(0xff00, 0, 0, 0, 0, 0, 0, 0)
+	assertEquals(
+		addr.octets(),
+		new Uint8Array([255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+	)
+})
+
 Deno.test('equals', () => {
 	const addr1 = Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8)
 	const addr2 = Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8)

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -8,18 +8,38 @@ import { clampUint16 } from './utils.ts'
  */
 export class SocketAddrV4 {
 	/** The IPv4 address of the socket */
-	public addr: Ipv4Addr
+	public readonly addr: Ipv4Addr
 	/** The unsigned 16-bit port number of the address */
-	public port: number
+	public readonly port: number
 
 	/**
 	 * Creates a new socket address from an IPv4 address and a port number.
+	 *
+	 * **Note**: It is the caller's responsibility to check that the port
+	 * number passed is an integer (not `NaN`, `Infinity`, or  `-Infinity`)
+	 * and is within the range of an unsigned 16-bit integer.
+	 *
 	 * @param addr The IPv4 address of the socket
 	 * @param port The unsigned 16-bit port number of the address
 	 */
 	public constructor(addr: Ipv4Addr, port: number) {
 		this.addr = addr
 		this.port = port
+	}
+
+	/**
+	 * Attempts to create a new `SocketAddrV4`.
+	 *
+	 * If the port is not an integer (including `NaN`, `Infinity`, and `-Infinity`),
+	 * then this will return null. Otherwise, the port number will be clamped and
+	 * truncated to an unsigned 16-bit integer.
+	 */
+	public static tryNew(addr: Ipv4Addr, port: number): SocketAddrV4 | null {
+		if (Number.isInteger(port)) {
+			return null
+		}
+
+		return new SocketAddrV4(addr, clampUint16(port))
 	}
 
 	/**
@@ -51,12 +71,17 @@ export class SocketAddrV4 {
  */
 export class SocketAddrV6 {
 	/** The IPv6 address of the socket */
-	public addr: Ipv6Addr
+	public readonly addr: Ipv6Addr
 	/** The unsigned 16-bit port number of the address */
-	public port: number
+	public readonly port: number
 
 	/**
 	 * Creates a new socket address from an IPv6 address and a port number.
+	 *
+	 * **Note**: It is the caller's responsibility to check that the port
+	 * number passed is an integer (not `NaN`, `Infinity`, or  `-Infinity`)
+	 * and is within the range of an unsigned 16-bit integer.
+	 *
 	 * @param addr The IPv6 address of the socket
 	 * @param port The unsigned 16-bit port number of the address
 	 */
@@ -66,16 +91,28 @@ export class SocketAddrV6 {
 	}
 
 	/**
-	 * Parses a string in the format of `"[ipv6]:port"`,
-	 * where the port is an unsigned 16-bit integer.
+	 * Attempts to create a new `SocketAddrV6`.
 	 *
-	 * TODO: Finish this implementation
+	 * If the port is not an integer (including `NaN`, `Infinity`, and `-Infinity`),
+	 * then this will return null. Otherwise, the port number will be clamped and
+	 * truncated to an unsigned 16-bit integer.
 	 */
-	public static fromString(s: string): SocketAddrV6 | null {
-		if (s[0] !== '[') {
+	public static tryNew(addr: Ipv6Addr, port: number): SocketAddrV6 | null {
+		if (Number.isInteger(port)) {
 			return null
 		}
 
-		return null
+		return new SocketAddrV6(addr, clampUint16(port))
+	}
+
+	/**
+	 * Parses a string in the format of `"[ipv6]:port"`,
+	 * where the port is an unsigned 16-bit integer.
+	 *
+	 * TODO: Finish this implementation. This will currently
+	 * throw an error since it is not implemented yet.
+	 */
+	public static parse(_s: string): SocketAddrV6 | null {
+		throw new Error('Not implemented yet')
 	}
 }

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -15,7 +15,7 @@ export class SocketAddrV4 {
 	/**
 	 * Creates a new socket address from an IPv4 address and a port number.
 	 *
-	 * **Note**: It is the caller's responsibility to check that the port
+	 * **NOTE**: It is the caller's responsibility to check that the port
 	 * number passed is an integer (not `NaN`, `Infinity`, or  `-Infinity`)
 	 * and is within the range of an unsigned 16-bit integer.
 	 *
@@ -78,7 +78,7 @@ export class SocketAddrV6 {
 	/**
 	 * Creates a new socket address from an IPv6 address and a port number.
 	 *
-	 * **Note**: It is the caller's responsibility to check that the port
+	 * **NOTE**: It is the caller's responsibility to check that the port
 	 * number passed is an integer (not `NaN`, `Infinity`, or  `-Infinity`)
 	 * and is within the range of an unsigned 16-bit integer.
 	 *

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -35,7 +35,7 @@ export class SocketAddrV4 {
 	 * truncated to an unsigned 16-bit integer.
 	 */
 	public static tryNew(addr: Ipv4Addr, port: number): SocketAddrV4 | null {
-		if (Number.isInteger(port)) {
+		if (!Number.isInteger(port)) {
 			return null
 		}
 
@@ -98,7 +98,7 @@ export class SocketAddrV6 {
 	 * truncated to an unsigned 16-bit integer.
 	 */
 	public static tryNew(addr: Ipv6Addr, port: number): SocketAddrV6 | null {
-		if (Number.isInteger(port)) {
+		if (!Number.isInteger(port)) {
 			return null
 		}
 

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -1,6 +1,42 @@
-import { assert, assertEquals } from '@std/assert'
+import { assert } from '@std/assert/assert'
+import { assertEquals } from '@std/assert/equals'
+import { assertInstanceOf } from '@std/assert/instance-of'
 import { Ipv4Addr } from './ipv4.ts'
+import { Ipv6Addr } from './ipv6.ts'
 import { SocketAddrV4 } from './socket.ts'
+import { SocketAddrV6 } from './socket.ts'
+
+Deno.test('socket address v4: tryNew is ok', () => {
+	const socket = SocketAddrV4.tryNew(
+		Ipv4Addr.newAddr(127, 0, 0, 1),
+		8080
+	)
+	assertInstanceOf(socket, SocketAddrV4)
+})
+
+Deno.test('socket address v4: tryNew errors if port is NaN', () => {
+	const socket = SocketAddrV4.tryNew(
+		Ipv4Addr.newAddr(127, 0, 0, 1),
+		Number.NaN
+	)
+	assertEquals(socket, null)
+})
+
+Deno.test('socket address v4: tryNew errors if port is +Infinity', () => {
+	const socket = SocketAddrV4.tryNew(
+		Ipv4Addr.newAddr(127, 0, 0, 1),
+		Number.POSITIVE_INFINITY
+	)
+	assertEquals(socket, null)
+})
+
+Deno.test('socket address v4: tryNew errors if port is -Infinity', () => {
+	const socket = SocketAddrV4.tryNew(
+		Ipv4Addr.newAddr(127, 0, 0, 1),
+		Number.NEGATIVE_INFINITY
+	)
+	assertEquals(socket, null)
+})
 
 Deno.test('socket addresss v4: parse is ok', () => {
 	const socket = SocketAddrV4.parse('127.0.0.1:8080')
@@ -36,5 +72,37 @@ Deno.test('socket address v4: parse is error, no port', () => {
 
 Deno.test('socket address v4: parse is error, port is out of bounds', () => {
 	const socket = SocketAddrV4.parse('127.0.0.1:65536')
+	assertEquals(socket, null)
+})
+
+Deno.test('socket address v6: tryNew is ok', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
+		8080
+	)
+	assertInstanceOf(socket, SocketAddrV6)
+})
+
+Deno.test('socket address v6: tryNew errors if port is NaN', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
+		Number.NaN
+	)
+	assertEquals(socket, null)
+})
+
+Deno.test('socket address v6: tryNew errors if port is +Infinity', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
+		Number.POSITIVE_INFINITY
+	)
+	assertEquals(socket, null)
+})
+
+Deno.test('socket address v6: tryNew errors if port is -Infinity', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
+		Number.NEGATIVE_INFINITY
+	)
 	assertEquals(socket, null)
 })

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -9,7 +9,7 @@ import { SocketAddrV6 } from './socket.ts'
 Deno.test('socket address v4: tryNew is ok', () => {
 	const socket = SocketAddrV4.tryNew(
 		Ipv4Addr.newAddr(127, 0, 0, 1),
-		8080
+		8080,
 	)
 	assertInstanceOf(socket, SocketAddrV4)
 })
@@ -17,7 +17,7 @@ Deno.test('socket address v4: tryNew is ok', () => {
 Deno.test('socket address v4: tryNew errors if port is NaN', () => {
 	const socket = SocketAddrV4.tryNew(
 		Ipv4Addr.newAddr(127, 0, 0, 1),
-		Number.NaN
+		Number.NaN,
 	)
 	assertEquals(socket, null)
 })
@@ -25,7 +25,7 @@ Deno.test('socket address v4: tryNew errors if port is NaN', () => {
 Deno.test('socket address v4: tryNew errors if port is +Infinity', () => {
 	const socket = SocketAddrV4.tryNew(
 		Ipv4Addr.newAddr(127, 0, 0, 1),
-		Number.POSITIVE_INFINITY
+		Number.POSITIVE_INFINITY,
 	)
 	assertEquals(socket, null)
 })
@@ -33,7 +33,7 @@ Deno.test('socket address v4: tryNew errors if port is +Infinity', () => {
 Deno.test('socket address v4: tryNew errors if port is -Infinity', () => {
 	const socket = SocketAddrV4.tryNew(
 		Ipv4Addr.newAddr(127, 0, 0, 1),
-		Number.NEGATIVE_INFINITY
+		Number.NEGATIVE_INFINITY,
 	)
 	assertEquals(socket, null)
 })
@@ -78,7 +78,7 @@ Deno.test('socket address v4: parse is error, port is out of bounds', () => {
 Deno.test('socket address v6: tryNew is ok', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
-		8080
+		8080,
 	)
 	assertInstanceOf(socket, SocketAddrV6)
 })
@@ -86,7 +86,7 @@ Deno.test('socket address v6: tryNew is ok', () => {
 Deno.test('socket address v6: tryNew errors if port is NaN', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
-		Number.NaN
+		Number.NaN,
 	)
 	assertEquals(socket, null)
 })
@@ -94,7 +94,7 @@ Deno.test('socket address v6: tryNew errors if port is NaN', () => {
 Deno.test('socket address v6: tryNew errors if port is +Infinity', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
-		Number.POSITIVE_INFINITY
+		Number.POSITIVE_INFINITY,
 	)
 	assertEquals(socket, null)
 })
@@ -102,7 +102,7 @@ Deno.test('socket address v6: tryNew errors if port is +Infinity', () => {
 Deno.test('socket address v6: tryNew errors if port is -Infinity', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.newAddr(1, 2, 3, 4, 5, 6, 7, 8),
-		Number.NEGATIVE_INFINITY
+		Number.NEGATIVE_INFINITY,
 	)
 	assertEquals(socket, null)
 })


### PR DESCRIPTION
### Breaking changes

- The interface `IpAddrValue` now exposes an `octets()` method that returns a `Uint8Array`.
- The properties of `Ipv4Addr` and `Ipv6Addr` are now readonly.
- The properties of `SocketAddrV4` and `SocketAddrV6` are now readonly.
- `SocketAddrV6.fromString()` is renamed to `SocketAddrV6.parse()` to be consistent with `SocketAddrV4.parse()`. (**Note**: This method is not currently implemented yet, and will throw an error when called)

### Features

- `SocketAddrV4` and `SocketAddrV6` now exposes a static `tryNew()` method. This method will check if the port number is a valid, unsigned 16-bit integer.
- `SocketAddrV4` and `SocketAddrV6` now have a note on their constructors which states that the caller is responsible for checking that the port is a valid, unsigned 16-bit integer.