### PR TITLE
feat: integer conversions for ipv4/ipv6, get previous/next ipv6addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.0
+
+### Features
+
+- `Ipv4Addr` now exposes an instance method named `toUint32()`.
+- `Ipv6Addr` now exposes 4 new instance methods:
+  - `toUint128()`
+  - `fromUint128()`, for constructing a new `Ipv6Addr` from a `bigint`
+  - `previous()`, for getting the previous IPv6 address
+  - `next()`, for getting the next IPv6 address
+
 ## 0.3.0
 
 ### Breaking changes

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nc/net-addr",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"license": "MIT",
 	"tasks": {
 		"dev": "deno test --watch src/mod.ts"

--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -82,7 +82,7 @@ export class Ipv4Addr implements IpAddrValue {
 	}
 
 	/**
-	 * Creates an IP address from an unsigned 32-bit integer.
+	 * Creates an IPv4 address from an unsigned 32-bit integer.
 	 *
 	 * If the given number is **not** within the range
 	 * (0 to 4,294,967,295), it will clamp it to be within the range.
@@ -192,19 +192,26 @@ export class Ipv4Addr implements IpAddrValue {
 	}
 
 	/**
-	 * Returns the IP address in dot decimal notation.
+	 * Returns the IPv4 address as an unsigned 32-bit integer.
+	 */
+	public toUint32(): number {
+		return uint8ArrayToUint32(this._octets)
+	}
+
+	/**
+	 * Returns the IPv4 address in dot decimal notation.
 	 */
 	public toString(): string {
 		return `${this.a}.${this.b}.${this.c}.${this.d}`
 	}
 
 	/**
-	 * Returns the address that occurs before this address.
+	 * Returns the IPv4 address that occurs before this address.
 	 *
 	 * If the current address is `0.0.0.0`, this returns null.
 	 */
 	public previous(): Ipv4Addr | null {
-		const n = uint8ArrayToUint32(this._octets) - 1
+		const n = this.toUint32() - 1
 		if (n < 0) {
 			return null
 		}
@@ -213,12 +220,12 @@ export class Ipv4Addr implements IpAddrValue {
 	}
 
 	/**
-	 * Returns the address that occurs after this address.
+	 * Returns the IPv4 address that occurs after this address.
 	 *
 	 * If the current address is `255.255.255.255`, this returns null.
 	 */
 	public next(): Ipv4Addr | null {
-		const n = uint8ArrayToUint32(this._octets) + 1
+		const n = this.toUint32() + 1
 		if (n > 65535) {
 			return null
 		}

--- a/src/ipv4_test.ts
+++ b/src/ipv4_test.ts
@@ -115,6 +115,16 @@ Deno.test('try from dataview is error', () => {
 	assertEquals(Ipv4Addr.tryFromDataView(view), null)
 })
 
+Deno.test('to uint32 from 0.0.0.0', () => {
+	const ip = Ipv4Addr.newAddr(0, 0, 0, 0)
+	assertEquals(ip.toUint32(), 0)
+})
+
+Deno.test('to uint32 from 255.255.255.255', () => {
+	const ip = Ipv4Addr.newAddr(255, 255, 255, 255)
+	assertEquals(ip.toUint32(), Math.pow(2, 32) - 1)
+})
+
 Deno.test('to string', () => {
 	const localhost = Ipv4Addr.LOCALHOST
 	assertEquals(localhost.toString(), '127.0.0.1')

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -208,7 +208,7 @@ export class Ipv6Addr implements IpAddrValue {
 
 	/**
 	 * Returns this IPv6 address as an unsigned 128-bit integer
-	 * via a `BigInt`.
+	 * (via `bigint`).
 	 */
 	public toUint128(): bigint {
 		return uint128FromArray(this._segments)


### PR DESCRIPTION
Other stuff:
- removes some instances of `// deno-fmt-ignore` to let `deno fmt` naturally format code
- minor improvements to docblocks