### PR TITLE
feat: introduce SocketAddr + SocketAddrValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - Introduced a new `SocketAddrValue` interface, which defines an `addr` getter, a `port` getter, and a `toString()` method.
+  - Note that `Ipv6Addr` does not yet have a way of converting to a string in its most compressed format. This means that `SocketAddrV6.toString()` will write out the inner IPv6 address in its uncompressed format, and the same goes the same for a `SocketAddr` if it contains a `SocketAddrV6`. Both issues will be addressed in an upcoming version.
 - Introduced a new `SocketAddr` class, which implements `SocketAddrValue`.
 - `SocketAddrV4` class now implements the `SocketAddrValue` interface.
 - `SocketddrV6` class now implemens the `SocketAddrValue` interface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.2
+
+### Features
+- Introduced a new `SocketAddrValue` interface, which defines an `addr` getter, a `port` getter, and a `toString()` method.
+- Introduced a new `SocketAddr` class, which implements `SocketAddrValue`.
+- `SocketAddrV4` class now implements the `SocketAddrValue` interface.
+- `SocketddrV6` class now implemens the `SocketAddrValue` interface.
+
+### Bug fixes
+- `SocketAddrV6` now correctly also contains a `flowInfo` property and `scopeId` property. (**NOTE**: This is technically considered a breaking change, but is classified as a bugfix instead since the original implementation before this version was incorrect.)
+- The constructor of `SocketAddrV6` is now considered "unchecked"; library users must take to check that all given numbers are within their valid range.
+
 ## 0.6.1
 
 ### Features

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nc/net-addr",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"license": "MIT",
 	"tasks": {
 		"dev": "deno test --watch src/mod.ts"

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -160,6 +160,8 @@ export interface SocketAddrValue {
 export class SocketAddr implements SocketAddrValue {
 	/** The socket address */
 	public socket: SocketAddrValue
+
+	/** Creates a new socket address */
 	public constructor(socket: SocketAddrValue) {
 		this.socket = socket
 	}

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -5,7 +5,7 @@ import { assertInstanceOf } from '@std/assert/instance-of'
 import { randomIntegerBetween } from '@std/random/integer-between'
 import { Ipv4Addr } from './ipv4.ts'
 import { Ipv6Addr } from './ipv6.ts'
-import { Port } from './socket.ts'
+import { Port, SocketAddr } from './socket.ts'
 import { SocketAddrV4 } from './socket.ts'
 import { SocketAddrV6 } from './socket.ts'
 
@@ -49,6 +49,41 @@ Deno.test('port: create a selectable ephemeral port', () => {
 
 	const maxPort = new Port(65535)
 	assert(maxPort.isSelectableEphemeral)
+})
+
+Deno.test('socket address: get port', () => {
+	const innerv4 = new SocketAddrV4(Ipv4Addr.LOCALHOST, new Port(3000))
+	const v4 = new SocketAddr(innerv4)
+	assertEquals(v4.port.value, 3000)
+
+	const innerv6 = new SocketAddrV6(Ipv6Addr.LOCALHOST, new Port(3000), 0, 0)
+	const v6 = new SocketAddr(innerv6)
+	assertEquals(v6.port.value, 3000)
+})
+
+Deno.test('socket address: get ip address', () => {
+	const innerv4 = new SocketAddrV4(Ipv4Addr.LOCALHOST, new Port(3000))
+	const v4 = new SocketAddr(innerv4)
+	assertEquals(v4.addr, Ipv4Addr.LOCALHOST)
+
+	const innerv6 = new SocketAddrV6(Ipv6Addr.LOCALHOST, new Port(3000), 0, 0)
+	const v6 = new SocketAddr(innerv6)
+	assertEquals(v6.addr, Ipv6Addr.LOCALHOST)
+})
+
+Deno.test('socket address: get v4 as string', () => {
+	const innerv4 = new SocketAddrV4(Ipv4Addr.LOCALHOST, new Port(3000))
+	const v4 = new SocketAddr(innerv4)
+	assertEquals(v4.toString(), '127.0.0.1:3000')
+})
+
+Deno.test('socket address: get v6 as string', () => {
+	const innerv6 = new SocketAddrV6(Ipv6Addr.LOCALHOST, new Port(3000), 0, 0)
+	const v6 = new SocketAddr(innerv6)
+	assertEquals(
+		v6.toString(),
+		'[0000:0000:0000:0000:0000:0000:0000:0001]:3000',
+	)
 })
 
 Deno.test('socket address v4: constructor does not validate port number (too small)', () => {
@@ -161,6 +196,8 @@ Deno.test('socket address v6: constructor does not validate port number (too sma
 	const socket = new SocketAddrV6(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		new Port(-1),
+		0,
+		0,
 	)
 	assertEquals(socket.port.value, -1)
 })
@@ -169,6 +206,8 @@ Deno.test('socket address v6: constructor does not validate port number (too big
 	const socket = new SocketAddrV6(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		new Port(65536),
+		0,
+		0,
 	)
 	assertEquals(socket.port.value, 65536)
 })
@@ -177,6 +216,8 @@ Deno.test('socket address v6: tryNew is ok', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		8080,
+		0,
+		0,
 	)
 	assertInstanceOf(socket, SocketAddrV6)
 })
@@ -185,6 +226,8 @@ Deno.test('socket address v6: tryNew errors if port is NaN', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		Number.NaN,
+		0,
+		0,
 	)
 	assertEquals(socket, null)
 })
@@ -193,6 +236,8 @@ Deno.test('socket address v6: tryNew errors if port is +Infinity', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		Number.POSITIVE_INFINITY,
+		0,
+		0,
 	)
 	assertEquals(socket, null)
 })
@@ -201,6 +246,8 @@ Deno.test('socket address v6: tryNew errors if port is -Infinity', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		Number.NEGATIVE_INFINITY,
+		0,
+		0,
 	)
 	assertEquals(socket, null)
 })
@@ -209,6 +256,8 @@ Deno.test('socket address v6: tryNew errors if port is less than 0', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		-1,
+		0,
+		0,
 	)
 	assertEquals(socket, null)
 })
@@ -217,6 +266,8 @@ Deno.test('socket address v6: tryNew errors if port is greater than 65,535', () 
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8) as Ipv6Addr,
 		65536,
+		0,
+		0,
 	)
 	assertEquals(socket, null)
 })

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -271,3 +271,31 @@ Deno.test('socket address v6: tryNew errors if port is greater than 65,535', () 
 	)
 	assertEquals(socket, null)
 })
+
+Deno.test('socket address v6: to string when scope id is 0', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.LOCALHOST,
+		3000,
+		0,
+		0,
+	)
+	assertInstanceOf(socket, SocketAddrV6)
+	assertEquals(
+		socket.toString(),
+		'[0000:0000:0000:0000:0000:0000:0000:0001]:3000',
+	)
+})
+
+Deno.test('socket address v6: to string when scope id is not 0', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.LOCALHOST,
+		3000,
+		0,
+		1,
+	)
+	assertInstanceOf(socket, SocketAddrV6)
+	assertEquals(
+		socket.toString(),
+		'[0000:0000:0000:0000:0000:0000:0000:0001%1]:3000',
+	)
+})

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -272,6 +272,26 @@ Deno.test('socket address v6: tryNew errors if port is greater than 65,535', () 
 	assertEquals(socket, null)
 })
 
+Deno.test('socket address v6: tryNew errors if flow info is not a uint32', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.LOCALHOST,
+		3000,
+		2 ** 32,
+		0,
+	)
+	assertEquals(socket, null)
+})
+
+Deno.test('socket address v6: tryNew errors if scope id is not a uint32', () => {
+	const socket = SocketAddrV6.tryNew(
+		Ipv6Addr.LOCALHOST,
+		3000,
+		0,
+		2 ** 32,
+	)
+	assertEquals(socket, null)
+})
+
 Deno.test('socket address v6: to string when scope id is 0', () => {
 	const socket = SocketAddrV6.tryNew(
 		Ipv6Addr.LOCALHOST,


### PR DESCRIPTION
This also fixes the implementation of `SocketAddrV6`, which now correctly holds a `flowInfo` property and a `scopeId` property.