### PR TITLE
feat: add some methods to Ipv6Addr, minor updates

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# rename a bunch of IP files to export under /ip
+# https://github.com/nodecitylights/net-addr/pull/15
+f4ff5d474bd51ac2c271c771913c97e2a4d065ed

--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check types
         run: deno check $ENTRYPOINT
       - name: Run tests
-        run: deno test -A
+        run: deno test -A ./src --doc README.md
 
   codequality:
     name: codequality (${{ matrix.job-name }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Internal
 - This also adds some unit tests for pre-existing methods, `Ipv6Addr.tryNew()` and `Ipv6Addr.isIpv4Mapped()`.
+- `.git-blame-ignore-revs` file is now setup.
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
 
 ### Documentation
 - The documentation for the `Ipv6Addr.isIpv4Mapped()` method now mentions its relevant RFC (RFC 4291).
+- The code example in `README.md` is now fixed.
+- The syntax highlighting in the install section is now fixed.
 
 ### Internal
 - This also adds some unit tests for pre-existing methods, `Ipv6Addr.tryNew()` and `Ipv6Addr.isIpv4Mapped()`.
 - `.git-blame-ignore-revs` file is now setup.
+- The CI workflow will now also run tests for any code examples set in `README.md`.
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - The `Ipv6Addr` class now exposes 2 instance methods, `isDiscardOnly()` and `isIpv4Translated()`.
 
+### Documentation
+- The documentation for the `Ipv6Addr.isIpv4Mapped()` method now mentions its relevant RFC (RFC 4291).
+
 ## 0.7.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Documentation
 - The documentation for the `Ipv6Addr.isIpv4Mapped()` method now mentions its relevant RFC (RFC 4291).
 
+### Internal
+- This also adds some unit tests for pre-existing methods, `Ipv6Addr.tryNew()` and `Ipv6Addr.isIpv4Mapped()`.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.1
+
+### Features
+- The `Ipv6Addr` class now exposes 2 instance methods, `isDiscardOnly()` and `isIpv4Translated()`.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ npx jsr add @nc/net-addr   # npm
 ## Usage
 ### IPv4 addresses
 ```ts
-import { assert, assertEquals } from '@std/assert'
-import { IPv4Addr } from '@nc/net-addr/v4'
+import { assertEquals } from '@std/assert'
+import { Ipv4Addr } from '@nc/net-addr/ip'
 
-const ip1 = IPv4Addr.newAddr(127, 0, 0, 1)
-const ip2 = IPv4Addr.tryFromUint8Array(new Uint8Array([127, 0, 0, 0, 1]))
+const ip0 = Ipv4Addr.parse('127.0.0.1')
+const ip1 = Ipv4Addr.tryNew(127, 0, 0, 1)
+const ip2 = Ipv4Addr.tryFromArray([127, 0, 0, 1])
+const ip3 = Ipv4Addr.tryFromUint32(2_130_706_433)
+const ip4 = Ipv4Addr.tryFromUint8Array(new Uint8Array([127, 0, 0, 1]))
 
-assert(ip1.equals(ip2))
+assertEquals(ip0, ip1)
+assertEquals(ip0, ip2)
+assertEquals(ip0, ip3)
+assertEquals(ip0, ip4)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library is a TypeScript port of Rust's network address types from the `std::net` module.
 
 ## Install
-```shell
+```sh
 deno add jsr:@nc/net-addr  # deno
 npx jsr add @nc/net-addr   # npm
 ```

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nc/net-addr",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"license": "MIT",
 	"tasks": {
 		"dev": "deno test --watch src/mod.ts"

--- a/src/ip/ipv6.ts
+++ b/src/ip/ipv6.ts
@@ -320,6 +320,21 @@ export class Ipv6Addr implements IpAddrValue {
 	}
 
 	/**
+	 * Checks if this IPv6 address is a discard-only address.
+	 *
+	 * This range is defined in [IETF RFC 6666][rfc6666] as
+	 * `100::/64`.
+	 *
+	 * [rfc6666]: https://datatracker.ietf.org/doc/html/rfc6666
+	 */
+	public isDiscardOnly(): boolean {
+		return arrayStartsWith(
+			this._segments,
+			new Uint16Array([0x100, 0, 0, 0]),
+		)
+	}
+
+	/**
 	 * Checks if this IPv6 address is a global address as specified
 	 * by the [IANA IPv6 Special-Purpose Address Registry][registry].
 	 *
@@ -327,15 +342,11 @@ export class Ipv6Addr implements IpAddrValue {
 	 */
 	// deno-fmt-ignore
 	public isGlobal(): boolean {
-		const ipv4Mapped = new Uint16Array([0, 0, 0, 0, 0, 0xffff])
-		const ipv4Translated = new Uint16Array([0x64, 0xff9b, 1])
-		const discardOnly = new Uint16Array([0x100, 0, 0, 0])
-
 		return !(this.isUnspecified()
 			|| this.isLoopback()
-			|| arrayStartsWith(this._segments, ipv4Mapped)
-			|| arrayStartsWith(this._segments, ipv4Translated)
-			|| arrayStartsWith(this._segments, discardOnly)
+			|| this.isIpv4Mapped()
+			|| this.isIpv4Translated()
+			|| this.isDiscardOnly()
 			|| (
 				(this.a === 0x2001 && this.b < 0x200) && !(
 					uint128FromArray(this._segments) === BigInt("0x20010001000000000000000000000001")
@@ -352,13 +363,31 @@ export class Ipv6Addr implements IpAddrValue {
 	}
 
 	/**
-	 * Checks if this IPv6 address is an IPv4-mapped address,
-	 * aka `::ffff:0:0/96`.
+	 * Checks if this IPv6 address is an IPv4-mapped address.
+	 *
+	 * This is defined in [IETF RFC 4291][rfc4291] as
+	 * `::ffff:0:0/96`.
+	 *
+	 * [rfc4291]: https://datatracker.ietf.org/doc/html/rfc4291
 	 */
 	public isIpv4Mapped(): boolean {
 		return arrayStartsWith(
 			this._segments,
 			new Uint16Array([0, 0, 0, 0, 0, 0xffff]),
+		)
+	}
+
+	/**
+	 * Checks if this IPv6 address is an IPv4-translated address.
+	 *
+	 * This is defined in [IETF RFC 8215][rfc8215] as`64:ff9b:1::/48`.
+	 *
+	 * [rfc8215]: https://datatracker.ietf.org/doc/html/rfc8215
+	 */
+	public isIpv4Translated(): boolean {
+		return arrayStartsWith(
+			this._segments,
+			new Uint16Array([0x64, 0xff9b, 1]),
 		)
 	}
 

--- a/src/ip/ipv6_test.ts
+++ b/src/ip/ipv6_test.ts
@@ -223,6 +223,11 @@ Deno.test('is documentation', () => {
 	assert(Ipv6Addr.tryNew(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)?.isDocumentation())
 })
 
+Deno.test('is discard-only', () => {
+	assertFalse(Ipv6Addr.tryNew(0x1001, 0, 0, 0, 1, 2, 3, 4)?.isDiscardOnly())
+	assert(Ipv6Addr.tryNew(0x100, 0, 0, 0, 1, 2, 3, 4)?.isDiscardOnly())
+})
+
 // deno-fmt-ignore
 Deno.test('is global: unspecified is not', () => {
 	assertFalse(Ipv6Addr.UNSPECIFIED.isGlobal())
@@ -251,7 +256,7 @@ Deno.test('is global: yes', () => {
 	assert(Ipv6Addr.tryNew(0x26, 0, 0x1c9, 0, 0, 0xafc8, 0x10, 0x1)?.isGlobal())
 })
 
-Deno.test('is global: unicast address with link-local scope', () => {
+Deno.test('is global: unicast address with link-local scope is not', () => {
 	assertFalse(Ipv6Addr.tryNew(0xfe80, 0, 0, 0, 0, 0, 0, 0)?.isGlobal())
 	assertFalse(Ipv6Addr.tryNew(0xfe81, 0, 0, 0, 0, 0, 0, 1)?.isGlobal())
 })
@@ -263,6 +268,16 @@ Deno.test('is global: unique local address is not', () => {
 
 Deno.test('is global: 1st hextet as 0x2002 is not', () => {
 	assertFalse(Ipv6Addr.tryNew(0x2002, 0, 0, 0, 0, 0, 0, 0)?.isGlobal())
+})
+
+Deno.test('is ipv4-mapped', () => {
+	assert(Ipv6Addr.tryNew(0, 0, 0, 0, 0, 0xffff, 1, 2)?.isIpv4Mapped())
+	assertFalse(Ipv6Addr.tryNew(0, 0, 0, 0, 0, 0xfffe, 1, 2)?.isIpv4Mapped())
+})
+
+Deno.test('is ipv4-translated', () => {
+	assert(Ipv6Addr.tryNew(0x64, 0xff9b, 1, 2, 3, 4, 5, 6)?.isIpv4Translated())
+	assertFalse(Ipv6Addr.tryNew(0x64, 0, 1, 2, 3, 4, 5, 6)?.isIpv4Translated())
 })
 
 Deno.test('is loopback', () => {

--- a/src/ip/ipv6_test.ts
+++ b/src/ip/ipv6_test.ts
@@ -34,7 +34,7 @@ Deno.test('segments', () => {
 	)
 })
 
-Deno.test('new address', () => {
+Deno.test('try new address is ok', () => {
 	const addr = Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, 8)
 	assert(addr instanceof Ipv6Addr)
 	assertEquals(addr.a, 1)
@@ -45,6 +45,18 @@ Deno.test('new address', () => {
 	assertEquals(addr.f, 6)
 	assertEquals(addr.g, 7)
 	assertEquals(addr.h, 8)
+})
+
+Deno.test('try new address errors if any number is not a u16', () => {
+	const notU16 = 2 ** 16
+	assertEquals(Ipv6Addr.tryNew(notU16, 2, 3, 4, 5, 6, 7, 8), null)
+	assertEquals(Ipv6Addr.tryNew(1, notU16, 3, 4, 5, 6, 7, 8), null)
+	assertEquals(Ipv6Addr.tryNew(1, 2, notU16, 4, 5, 6, 7, 8), null)
+	assertEquals(Ipv6Addr.tryNew(1, 2, 3, notU16, 5, 6, 7, 8), null)
+	assertEquals(Ipv6Addr.tryNew(1, 2, 3, 4, notU16, 6, 7, 8), null)
+	assertEquals(Ipv6Addr.tryNew(1, 2, 3, 4, 5, notU16, 7, 8), null)
+	assertEquals(Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, notU16, 8), null)
+	assertEquals(Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, notU16), null)
 })
 
 Deno.test('from below range of uint128 returns null', () => {


### PR DESCRIPTION
### Features
 - The `Ipv6Addr` class now exposes 2 instance methods, `isDiscardOnly()` and `isIpv4Translated()`.

 ### Documentation
 - The documentation for the `Ipv6Addr.isIpv4Mapped()` method now mentions its relevant RFC (RFC 4291).
 - The code example in `README.md` is now fixed.
 - The syntax highlighting in the install section is now fixed.

 ### Internal
 - This also adds some unit tests for pre-existing methods, `Ipv6Addr.tryNew()` and `Ipv6Addr.isIpv4Mapped()`.
 - `.git-blame-ignore-revs` file is now setup.
 - The CI workflow will now also run tests for any code examples set in `README.md`.
 