### PR TITLE
feat: add canonical representation for IPv6 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.7
+
+### Features
+- `IPv6Addr` now returns its canonical string representation. This TypeScript implementation is ported over from Rust's implementation (`impl Display for std::net::Ipv6Addr`).
+
 ## 0.7.6
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 - `IPv6Addr` now returns its canonical string representation. This TypeScript implementation is ported over from Rust's implementation (`impl fmt::Display for Ipv6Addr`).
 
-### Internal
+### Internal changes
 - `Ipv4Addr.tryNew()` now has more extensive unit tests.
 
 ## 0.7.6
@@ -64,7 +64,7 @@
 - The code example in `README.md` is now fixed.
 - The syntax highlighting in the install section is now fixed.
 
-### Internal
+### Internal changes
 - This also adds some unit tests for pre-existing methods, `Ipv6Addr.tryNew()` and `Ipv6Addr.isIpv4Mapped()`.
 - `.git-blame-ignore-revs` file is now setup.
 - The CI workflow will now also run tests for any code examples set in `README.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.7
 
 ### Features
-- `IPv6Addr` now returns its canonical string representation. This TypeScript implementation is ported over from Rust's implementation (`impl Display for std::net::Ipv6Addr`).
+- `IPv6Addr` now returns its canonical string representation. This TypeScript implementation is ported over from Rust's implementation (`impl fmt::Display for Ipv6Addr`).
 
 ### Internal
 - `Ipv4Addr.tryNew()` now has more extensive unit tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - `IPv6Addr` now returns its canonical string representation. This TypeScript implementation is ported over from Rust's implementation (`impl Display for std::net::Ipv6Addr`).
 
+### Internal
+- `Ipv4Addr.tryNew()` now has more extensive unit tests.
+
 ## 0.7.6
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ assertEquals(socket.addr, Ipv6Addr.LOCALHOST)
 assertEquals(socket.port.value, 3000)
 assertEquals(socket.flowInfo, 0)
 assertEquals(socket.scopeId, 0)
+assertEquals(socket.toString(), '[::1]:3000')
 ```
 
 ## License

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"tasks": {
 		"check": "deno check ./src/mod.ts",
-		"test": "deno test -A src/ --doc README.md",
+		"test": "rm -rf coverage && deno test -A src/ --doc README.md --coverage",
 		"htmldocs": "deno doc --html ./src/mod.ts",
 		"lintdocs": "deno doc --lint ./src/mod.ts"
 	},

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nc/net-addr",
-	"version": "0.7.6",
+	"version": "0.7.7",
 	"license": "MIT",
 	"tasks": {
 		"check": "deno check ./src/mod.ts",

--- a/src/ip/ipv4.ts
+++ b/src/ip/ipv4.ts
@@ -32,6 +32,7 @@ import { parseIpv4Addr } from '../parser.ts'
  *
  * const localhost = Ipv4Addr.LOCALHOST
  *
+ * assertEquals(localhost.toString(), '127.0.0.1')
  * assertEquals(localhost.octets(), new Uint8Array([127, 0, 0, 1]))
  * assert(localhost.isLoopback())
  * assert(Ipv4Addr.tryNew(0, 0, 0, 0)?.isUnspecified())

--- a/src/ip/ipv4_test.ts
+++ b/src/ip/ipv4_test.ts
@@ -34,12 +34,19 @@ Deno.test('getters', () => {
 	assertEquals(addr.d, 4)
 })
 
-Deno.test('from below range of uint32 returns null', () => {
+Deno.test('try new address errors if any number is not a u8', () => {
+	assertEquals(Ipv4Addr.tryNew(256, 0, 0, 0), null)
+	assertEquals(Ipv4Addr.tryNew(0, 256, 0, 0), null)
+	assertEquals(Ipv4Addr.tryNew(0, 0, 256, 0), null)
+	assertEquals(Ipv4Addr.tryNew(0, 0, 0, 256), null)
+})
+
+Deno.test('try from below range of uint32 returns null', () => {
 	const addr = Ipv4Addr.tryFromUint32(-1)
 	assertEquals(addr, null)
 })
 
-Deno.test('from above range uint32 returns null', () => {
+Deno.test('try from above range uint32 returns null', () => {
 	const addr = Ipv4Addr.tryFromUint32(4_294_967_296)
 	assertEquals(addr, null)
 })

--- a/src/ip/ipv6.ts
+++ b/src/ip/ipv6.ts
@@ -361,14 +361,6 @@ export class Ipv6Addr implements IpAddrValue {
 		}
 	}
 
-	// if zeroes.len > 1 {
-	//        fmt_subslice(f, &segments[..zeroes.start])?;
-	//        f.write_str("::")?;
-	//        fmt_subslice(f, &segments[zeroes.start + zeroes.len..])
-	//    } else {
-	//        fmt_subslice(f, &segments)
-	//    }
-
 	/**
 	 * A fixed-size array of 16 unsigned 8-bit integers
 	 */

--- a/src/ip/ipv6.ts
+++ b/src/ip/ipv6.ts
@@ -25,11 +25,12 @@ import { arrayStartsWith, isValidUint128, isValidUint16 } from '../utils.ts'
  *
  * @example Properties of an IPv6 address
  * ```ts
- * import { assert, assertFalse } from '@std/assert'
+ * import { assert, assertEquals, assertFalse } from '@std/assert'
  * import { Ipv6Addr } from '@nc/net-addr/ip'
  *
  * const localhost = Ipv6Addr.LOCALHOST
  *
+ * assertEquals(localhost.toString(), '::1')
  * assert(localhost.isLoopback())
  * assertFalse(localhost.isBenchmarking())
  * assertFalse(localhost.isDocumentation())
@@ -301,16 +302,72 @@ export class Ipv6Addr implements IpAddrValue {
 	}
 
 	/**
-	 * This returns an IPv6 address as a fully uncompressed string,
-	 * as `aaaa:bbbb:cccc:dddd:eeee:ffff:gggg:hhhh`.
+	 * This returns an IPv6 address in its canonical representation,
+	 * according to [IETF RFC 5952][rfc5952].
+	 *
+	 * [rfc5952]: https://datatracker.ietf.org/doc/html/rfc5952
 	 */
 	public toString(): string {
-		const hextets = []
-		for (const segment of this._segments) {
-			hextets.push(segment.toString(16).padStart(4, '0'))
+		const mapped = this.toIpv4Mapped()
+		if (mapped !== null) {
+			return `::ffff:${mapped}`
 		}
-		return hextets.join(':')
+
+		// compute zeroes
+		let longest = { start: 0, len: 0 }
+		let current = { start: 0, len: 0 }
+
+		let i = 0
+		for (const segment of this._segments) {
+			if (segment === 0) {
+				if (current.len === 0) {
+					current.start = i
+				}
+
+				current.len++
+				if (current.len > longest.len) {
+					longest = current
+				}
+			} else {
+				current = { start: 0, len: 0 }
+			}
+			i++
+		}
+		const zeroes = longest
+
+		// format!
+		const formatSubslice = (chunk: Uint16Array): string => {
+			const splitFirst = arraySplitFirst(Array.from(chunk))
+			if (splitFirst === null) {
+				return ''
+			}
+
+			const [first, tail] = splitFirst
+			let buf = `${first.toString(16)}`
+			for (const segment of tail) {
+				buf += `:${segment.toString(16)}`
+			}
+			return buf
+		}
+
+		// deno-fmt-ignore
+		if (zeroes.len > 1) {
+			let buf = formatSubslice(this._segments.subarray(0, zeroes.start))
+			buf += '::'
+			buf += formatSubslice(this._segments.subarray(zeroes.start + zeroes.len))
+			return buf
+		} else {
+			return formatSubslice(this._segments)
+		}
 	}
+
+	// if zeroes.len > 1 {
+	//        fmt_subslice(f, &segments[..zeroes.start])?;
+	//        f.write_str("::")?;
+	//        fmt_subslice(f, &segments[zeroes.start + zeroes.len..])
+	//    } else {
+	//        fmt_subslice(f, &segments)
+	//    }
 
 	/**
 	 * A fixed-size array of 16 unsigned 8-bit integers
@@ -626,6 +683,17 @@ export type Ipv6MulticastScope =
 	| 'SiteLocal'
 	| 'OrganizationLocal'
 	| 'Global'
+
+function arraySplitFirst<T>(
+	array: Array<T>,
+): [T, T[]] | null {
+	if (array.length === 0) {
+		return null
+	}
+
+	const [first, ...rest] = array
+	return [first, rest]
+}
 
 function uint8ArrayToUint16Array(array: Uint8Array): Uint16Array {
 	const uint16Array = new Uint16Array(8)

--- a/src/ip/ipv6_test.ts
+++ b/src/ip/ipv6_test.ts
@@ -60,12 +60,12 @@ Deno.test('try new address errors if any number is not a u16', () => {
 	assertEquals(Ipv6Addr.tryNew(1, 2, 3, 4, 5, 6, 7, notU16), null)
 })
 
-Deno.test('from below range of uint128 returns null', () => {
+Deno.test('try from below range of uint128 returns null', () => {
 	const addr = Ipv6Addr.tryFromUint128(-1n)
 	assertEquals(addr, null)
 })
 
-Deno.test('from above range of uint128 returns null', () => {
+Deno.test('try from above range of uint128 returns null', () => {
 	const addr = Ipv6Addr.tryFromUint128(2n ** 128n)
 	assertEquals(addr, null)
 })

--- a/src/ip/ipv6_test.ts
+++ b/src/ip/ipv6_test.ts
@@ -159,15 +159,17 @@ Deno.test('to uint128 from ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', () => {
 	assertEquals(addr?.toUint128(), (2n ** 128n) - 1n)
 })
 
-Deno.test('localhost to full string', () => {
-	const localhost = Ipv6Addr.LOCALHOST
-	assertEquals(
-		localhost.toString(),
-		'0000:0000:0000:0000:0000:0000:0000:0001',
-	)
+Deno.test('unspecified to string', () => {
+	const unspecified = Ipv6Addr.UNSPECIFIED
+	assertEquals(unspecified.toString(), '::')
 })
 
-Deno.test('address with hex characters to full string', () => {
+Deno.test('localhost to string', () => {
+	const localhost = Ipv6Addr.LOCALHOST
+	assertEquals(localhost.toString(), '::1')
+})
+
+Deno.test('some address to string', () => {
 	const addr = Ipv6Addr.tryNew(
 		0x1234,
 		0x5678,

--- a/src/ip/ipv6_test.ts
+++ b/src/ip/ipv6_test.ts
@@ -169,7 +169,37 @@ Deno.test('localhost to string', () => {
 	assertEquals(localhost.toString(), '::1')
 })
 
-Deno.test('some address to string', () => {
+Deno.test('address to string with ipv4-mapped address', () => {
+	const addr = Ipv6Addr.tryNew(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x280)
+	assertEquals(addr?.toString(), '::ffff:192.0.2.128')
+})
+
+Deno.test('address to string with ipv4-compatible address', () => {
+	const addr = Ipv6Addr.tryNew(0, 0, 0, 0, 0, 0, 0xc000, 0x280)
+	assertEquals(addr?.toString(), '::c000:280')
+})
+
+Deno.test('address to string, remove a single set of zeroes', () => {
+	const addr = Ipv6Addr.tryNew(0xae, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304)
+	assertEquals(addr?.toString(), 'ae::ffff:102:304')
+})
+
+Deno.test('address to string, ends in zeroes', () => {
+	const addr = Ipv6Addr.tryNew(1, 0, 0, 0, 0, 0, 0, 0)
+	assertEquals(addr?.toString(), '1::')
+})
+
+Deno.test('address to string with two runs of zeros, second one is longer', () => {
+	const addr = Ipv6Addr.tryNew(1, 0, 0, 4, 0, 0, 0, 8)
+	assertEquals(addr?.toString(), '1:0:0:4::8')
+})
+
+Deno.test('address to string with two runs of zeros, equal length', () => {
+	const addr = Ipv6Addr.tryNew(1, 0, 0, 4, 5, 0, 0, 8)
+	assertEquals(addr?.toString(), '1::4:5:0:0:8')
+})
+
+Deno.test('address to string, longest possible', () => {
 	const addr = Ipv6Addr.tryNew(
 		0x1234,
 		0x5678,

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -77,15 +77,6 @@ Deno.test('socket address: get v4 as string', () => {
 	assertEquals(v4.toString(), '127.0.0.1:3000')
 })
 
-Deno.test('socket address: get v6 as string', () => {
-	const innerv6 = new SocketAddrV6(Ipv6Addr.LOCALHOST, new Port(3000), 0, 0)
-	const v6 = new SocketAddr(innerv6)
-	assertEquals(
-		v6.toString(),
-		'[::1]:3000',
-	)
-})
-
 Deno.test('socket address v4: constructor does not validate port number (too small)', () => {
 	const socket = new SocketAddrV4(
 		Ipv4Addr.tryNew(127, 0, 0, 1) as Ipv4Addr,

--- a/src/socket_test.ts
+++ b/src/socket_test.ts
@@ -82,7 +82,7 @@ Deno.test('socket address: get v6 as string', () => {
 	const v6 = new SocketAddr(innerv6)
 	assertEquals(
 		v6.toString(),
-		'[0000:0000:0000:0000:0000:0000:0000:0001]:3000',
+		'[::1]:3000',
 	)
 })
 
@@ -302,7 +302,7 @@ Deno.test('socket address v6: to string when scope id is 0', () => {
 	assertInstanceOf(socket, SocketAddrV6)
 	assertEquals(
 		socket.toString(),
-		'[0000:0000:0000:0000:0000:0000:0000:0001]:3000',
+		'[::1]:3000',
 	)
 })
 
@@ -316,6 +316,6 @@ Deno.test('socket address v6: to string when scope id is not 0', () => {
 	assertInstanceOf(socket, SocketAddrV6)
 	assertEquals(
 		socket.toString(),
-		'[0000:0000:0000:0000:0000:0000:0000:0001%1]:3000',
+		'[::1%1]:3000',
 	)
 })


### PR DESCRIPTION
This TypeScript implementation is ported over from Rust's implementation (`impl fmt::Display for Ipv6Addr`).